### PR TITLE
Adding CopyAll option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,11 @@ Why then do we copy `MyModule.ts` at all if we are just going to rename it so Vi
 How to Change the Library Path
 ---------------------------
 If you want the copied files to go somewhere other than $(ProjectDir)libraries then you just need to add a property to a PropertyGroup of your .csproj file like `<TypeScriptLibraryFullPath>app\scripts</TypeScriptLibraryFullPath>`.
+
+What if I don't want the .ts or .js.map files to be copied?
+-----------------------------------------------------------
+If you don't want the .ts or .js.map files to be copied over then you can add a property to a propertygroup (same as for changing the library Path). This property should be:
+
+<TypeScriptLibraryCopyAll>false</TypeScriptLibraryCopyAll>
+
+The default value for this property (if it is ommitted) is true so it will copy over your .ts and .js.map files (though see note on renaming of .ts files).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ What if I don't want the .ts or .js.map files to be copied?
 -----------------------------------------------------------
 If you don't want the .ts or .js.map files to be copied over then you can add a property to a propertygroup (same as for changing the library Path). This property should be:
 
-<TypeScriptLibraryCopyAll>false</TypeScriptLibraryCopyAll>
+`<TypeScriptLibraryCopyAll>false</TypeScriptLibraryCopyAll>`
 
 The default value for this property (if it is ommitted) is true so it will copy over your .ts and .js.map files (though see note on renaming of .ts files).

--- a/code/FromReferencesTask.cs
+++ b/code/FromReferencesTask.cs
@@ -29,6 +29,14 @@ namespace Zoltu.BuildTools.TypeScript
 		}
 		private String _libraryDirectoryFullPath;
 
+		[Required]
+		public bool CopyAll
+		{
+			get { return _copyAll; }
+			set { _copyAll = value; }
+		}
+		private bool _copyAll;
+
 		public override Boolean Execute()
 		{
 			try
@@ -61,10 +69,13 @@ namespace Zoltu.BuildTools.TypeScript
 
 					CopyFile(sourceDirectoryPath, sourceFileName, LibraryDirectoryFullPath, ".d.ts", ".d.ts");
 					CopyFile(sourceDirectoryPath, sourceFileName, LibraryDirectoryFullPath, ".js", ".js");
-					var tsSourceFilePath = CopyFile(sourceDirectoryPath, sourceFileName, LibraryDirectoryFullPath, ".ts", ".ts.source");
-					var jsMapFilePath = CopyFile(sourceDirectoryPath, sourceFileName, LibraryDirectoryFullPath, ".js.map", ".js.map");
+					if (CopyAll)
+					{
+						var tsSourceFilePath = CopyFile(sourceDirectoryPath, sourceFileName, LibraryDirectoryFullPath, ".ts", ".ts.source");
+						var jsMapFilePath = CopyFile(sourceDirectoryPath, sourceFileName, LibraryDirectoryFullPath, ".js.map", ".js.map");
 
-					UpdateSourceMap(sourceFileName, jsMapFilePath, tsSourceFilePath);
+						UpdateSourceMap(sourceFileName, jsMapFilePath, tsSourceFilePath);
+					}
 				};
 
 				return true;

--- a/code/Zoltu.BuildTools.TypeScript.FromReferencesTask.targets
+++ b/code/Zoltu.BuildTools.TypeScript.FromReferencesTask.targets
@@ -4,7 +4,8 @@
 	<Target Name="CopyTypeScriptReferences" BeforeTargets="CompileTypeScript">
 		<PropertyGroup>
 			<TypeScriptLibraryFullPath Condition=" '$(TypeScriptLibraryFullPath)' == '' ">$(ProjectDir)libraries</TypeScriptLibraryFullPath>
+			<TypeScriptLibraryCopyAll Condition=" '$(TypeScriptLibraryCopyAll)' == '' ">true</TypeScriptLibraryCopyAll>
 		</PropertyGroup>
-		<Zoltu.BuildTools.TypeScript.FromReferencesTask ProjectFullPath="$(MSBuildProjectFullPath)" LibraryDirectoryFullPath="$(TypeScriptLibraryFullPath)"/>
+		<Zoltu.BuildTools.TypeScript.FromReferencesTask ProjectFullPath="$(MSBuildProjectFullPath)" LibraryDirectoryFullPath="$(TypeScriptLibraryFullPath)" CopyAll="$(TypeScriptLibraryCopyAll)"/>
 	</Target>
 </Project>


### PR DESCRIPTION
When we are copying files we only really want the .js and .d.ts files the .ts and .js.map files are not needed for us. My colleague commented on http://stackoverflow.com/questions/21233108/cross-project-references-between-two-projects/29159412#29159412 and since you suggested there that you'd be happy with a pull request with these changes here it is.

I've added an extra option that defaults to the current behaviour. I've not really played with build tasks before so the changes are modelled on the way you were doing things already rather than any knowledge on my part. That having been said they are simple enough that they should be fine (and certainly passed my limited testing).

I also updated the Readme to explain the new option.

I'm also pretty inexperienced with github so not sure how much more I should be saying here and so on. Let me know if there is anything else you need to know from me or anything else I should be doing to make this happen.
