### PR TITLE
Use Source Directory Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ How to Change the Library Path
 ---------------------------
 If you want the copied files to go somewhere other than $(ProjectDir)libraries then you just need to add a property to a PropertyGroup of your .csproj file like `<TypeScriptLibraryFullPath>app\scripts</TypeScriptLibraryFullPath>`.
 
-Additionally the default behaviour is to copy all files to the specified directory. If you want to preserve the folder structure of your TypeScript project then you can use the `TypeScriptLibraryUseDirectoryStructure` property like `<TypeScriptLibraryUseDirectoryStructure>true</TypeScriptLibraryUseDirectoryStructure>`. When this property is set to true it will use the folder structure of your Typescript project from the project root. So for example if you have a typescript file in `Scripts/Module1/MyScript.ts` then it will be copied to the `Scripts/Module1` directory in your library output folder. This setting defaults to false.
-
 What if I don't want the .ts or .js.map files to be copied?
 -----------------------------------------------------------
 If you don't want the .ts or .js.map files to be copied over then you can add a property to a propertygroup (same as for changing the library Path). This property should be:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ How to Change the Library Path
 ---------------------------
 If you want the copied files to go somewhere other than $(ProjectDir)libraries then you just need to add a property to a PropertyGroup of your .csproj file like `<TypeScriptLibraryFullPath>app\scripts</TypeScriptLibraryFullPath>`.
 
+Additionally the default behaviour is to copy all files to the specified directory. If you want to preserve the folder structure of your TypeScript project then you can use the `TypeScriptLibraryUseDirectoryStructure` property like `<TypeScriptLibraryUseDirectoryStructure>true</TypeScriptLibraryUseDirectoryStructure>`. When this property is set to true it will use the folder structure of your Typescript project from the project root. So for example if you have a typescript file in `Scripts/Module1/MyScript.ts` then it will be copied to the `Scripts/Module1` directory in your library output folder. This setting defaults to false.
+
 What if I don't want the .ts or .js.map files to be copied?
 -----------------------------------------------------------
 If you don't want the .ts or .js.map files to be copied over then you can add a property to a propertygroup (same as for changing the library Path). This property should be:

--- a/code/FromReferencesTask.cs
+++ b/code/FromReferencesTask.cs
@@ -104,6 +104,7 @@ namespace Zoltu.BuildTools.TypeScript
 		{
 			Contract.Requires(sourceProjectBasePath != null);
 			Contract.Requires(sourceDirectoryPath != null);
+			Contract.Ensures(!String.IsNullOrEmpty(Contract.Result<string>()));
 			Contract.Assume(sourceDirectoryPath.Length > sourceProjectBasePath.Length);
 			Contract.Assume(!String.IsNullOrEmpty(LibraryDirectoryFullPath));
 			var rootRelativePath = sourceDirectoryPath.Remove(0, sourceProjectBasePath.Length);

--- a/code/FromReferencesTask.cs
+++ b/code/FromReferencesTask.cs
@@ -104,7 +104,7 @@ namespace Zoltu.BuildTools.TypeScript
 		{
 			Contract.Requires(sourceProjectBasePath != null);
 			Contract.Requires(sourceDirectoryPath != null);
-			Contract.Ensures(!String.IsNullOrEmpty(Contract.Result<string>()));
+			Contract.Ensures(Contract.Result<string>()!=null);
 			Contract.Assume(sourceDirectoryPath.Length > sourceProjectBasePath.Length);
 			Contract.Assume(!String.IsNullOrEmpty(LibraryDirectoryFullPath));
 			var rootRelativePath = sourceDirectoryPath.Remove(0, sourceProjectBasePath.Length);

--- a/code/FromReferencesTask.cs
+++ b/code/FromReferencesTask.cs
@@ -73,7 +73,6 @@ namespace Zoltu.BuildTools.TypeScript
 						var sourceDirectoryPath = Path.GetDirectoryName(typeScriptFullPath);
 						Contract.Assume(!String.IsNullOrEmpty(sourceDirectoryPath));
 						string destinationPath = GetDestinationPath(sourceProjectBasePath, sourceDirectoryPath);
-						Contract.Assume(!String.IsNullOrEmpty(destinationPath));
 						Directory.CreateDirectory(destinationPath);
 						var sourceFileName = Path.GetFileNameWithoutExtension(typeScriptFullPath);
 						Contract.Assume(!String.IsNullOrEmpty(sourceFileName));
@@ -105,6 +104,7 @@ namespace Zoltu.BuildTools.TypeScript
 		{
 			Contract.Requires(sourceProjectBasePath != null);
 			Contract.Requires(sourceDirectoryPath != null);
+			Contract.Ensures(!String.IsNullOrEmpty(Contract.Result<string>()));
 			Contract.Assume(sourceDirectoryPath.Length > sourceProjectBasePath.Length);
 			Contract.Assume(!String.IsNullOrEmpty(LibraryDirectoryFullPath));
 			var rootRelativePath = sourceDirectoryPath.Remove(0, sourceProjectBasePath.Length);
@@ -112,7 +112,9 @@ namespace Zoltu.BuildTools.TypeScript
 			{
 				rootRelativePath = rootRelativePath.Substring(1);
 			}
-			return Path.Combine(LibraryDirectoryFullPath, rootRelativePath);
+			string combinedPath = Path.Combine(LibraryDirectoryFullPath, rootRelativePath);
+			Contract.Assume(!String.IsNullOrEmpty(combinedPath));
+			return combinedPath;
 		}
 		private static INotNullEnumerable<ProjectRootElement> GetReferencedProjects(ProjectRootElement parentProject)
 		{

--- a/code/FromReferencesTask.cs
+++ b/code/FromReferencesTask.cs
@@ -73,6 +73,7 @@ namespace Zoltu.BuildTools.TypeScript
 						var sourceDirectoryPath = Path.GetDirectoryName(typeScriptFullPath);
 						Contract.Assume(!String.IsNullOrEmpty(sourceDirectoryPath));
 						string destinationPath = GetDestinationPath(sourceProjectBasePath, sourceDirectoryPath);
+						Contract.Assume(!String.IsNullOrEmpty(destinationPath));
 						Directory.CreateDirectory(destinationPath);
 						var sourceFileName = Path.GetFileNameWithoutExtension(typeScriptFullPath);
 						Contract.Assume(!String.IsNullOrEmpty(sourceFileName));
@@ -104,7 +105,6 @@ namespace Zoltu.BuildTools.TypeScript
 		{
 			Contract.Requires(sourceProjectBasePath != null);
 			Contract.Requires(sourceDirectoryPath != null);
-			Contract.Ensures(Contract.Result<string>()!=null);
 			Contract.Assume(sourceDirectoryPath.Length > sourceProjectBasePath.Length);
 			Contract.Assume(!String.IsNullOrEmpty(LibraryDirectoryFullPath));
 			var rootRelativePath = sourceDirectoryPath.Remove(0, sourceProjectBasePath.Length);

--- a/code/Zoltu.BuildTools.TypeScript.FromReferencesTask.targets
+++ b/code/Zoltu.BuildTools.TypeScript.FromReferencesTask.targets
@@ -5,8 +5,7 @@
 		<PropertyGroup>
 			<TypeScriptLibraryFullPath Condition=" '$(TypeScriptLibraryFullPath)' == '' ">$(ProjectDir)libraries</TypeScriptLibraryFullPath>
 			<TypeScriptLibraryCopyAll Condition=" '$(TypeScriptLibraryCopyAll)' == '' ">true</TypeScriptLibraryCopyAll>
-			<TypeScriptLibraryUseDirectoryStructure Condition=" '$(TypeScriptLibraryUseDirectoryStructure)' == '' ">false</TypeScriptLibraryUseDirectoryStructure>
 		</PropertyGroup>
-		<Zoltu.BuildTools.TypeScript.FromReferencesTask ProjectFullPath="$(MSBuildProjectFullPath)" LibraryDirectoryFullPath="$(TypeScriptLibraryFullPath)" CopyAll="$(TypeScriptLibraryCopyAll)" UseSourceDirectoryStructure="$(TypeScriptLibraryUseDirectoryStructure)"/>
+		<Zoltu.BuildTools.TypeScript.FromReferencesTask ProjectFullPath="$(MSBuildProjectFullPath)" LibraryDirectoryFullPath="$(TypeScriptLibraryFullPath)" CopyAll="$(TypeScriptLibraryCopyAll)" />
 	</Target>
 </Project>

--- a/code/Zoltu.BuildTools.TypeScript.FromReferencesTask.targets
+++ b/code/Zoltu.BuildTools.TypeScript.FromReferencesTask.targets
@@ -5,7 +5,8 @@
 		<PropertyGroup>
 			<TypeScriptLibraryFullPath Condition=" '$(TypeScriptLibraryFullPath)' == '' ">$(ProjectDir)libraries</TypeScriptLibraryFullPath>
 			<TypeScriptLibraryCopyAll Condition=" '$(TypeScriptLibraryCopyAll)' == '' ">true</TypeScriptLibraryCopyAll>
+			<TypeScriptLibraryUseDirectoryStructure Condition=" '$(TypeScriptLibraryUseDirectoryStructure)' == '' ">false</TypeScriptLibraryUseDirectoryStructure>
 		</PropertyGroup>
-		<Zoltu.BuildTools.TypeScript.FromReferencesTask ProjectFullPath="$(MSBuildProjectFullPath)" LibraryDirectoryFullPath="$(TypeScriptLibraryFullPath)" CopyAll="$(TypeScriptLibraryCopyAll)"/>
+		<Zoltu.BuildTools.TypeScript.FromReferencesTask ProjectFullPath="$(MSBuildProjectFullPath)" LibraryDirectoryFullPath="$(TypeScriptLibraryFullPath)" CopyAll="$(TypeScriptLibraryCopyAll)" UseSourceDirectoryStructure="$(TypeScriptLibraryUseDirectoryStructure)"/>
 	</Target>
 </Project>


### PR DESCRIPTION
I've made some modifications to allow an extra flag to be passed that when set to true will make the copy process create a directory structure in the target location. The directory structure will mimic the directory structure where the .ts file lived.

eg if the source project has the following:

Scripts\Components\Module1.ts
Scripts\Pages\Page1.ts

And the destination path is set to

C:\projects\MyProject\

Then it will copy the files to:
C:\projects\MyProject\Scripts\Components\Module1.js
C:\projects\MyProject\Scripts\Pages\Page1.js

The reason behind this change is that if a file has a reference to another typescript file that is in a different directory then when copied these references will no longer be valid. 

Similar if it references .d.ts files that are not copied then these references break. The easiest way to have these references work is to have the type files in your destination in the same relative location and this requires a certain amount of preservation of the directory structure.

The code changes are relatively simple and described in the commit in detail. Broadly though a new property will determine whether to use the destination directory as is or run some logic to find the project root relative path of the source and then append that path fragment to the destination. Default behaviour is to not use the new functionality (ie default behaviour will be as per the previous version).

Let me know if you have any questions with any of this.
